### PR TITLE
feat: expand MetaInfo to udf1-15 and add tests

### DIFF
--- a/src/phonepe/sdk/pg/common/configs/Headers.php
+++ b/src/phonepe/sdk/pg/common/configs/Headers.php
@@ -25,7 +25,7 @@ class Headers
 	const APPLICATION_JSON = "application/json";
 
 	const SOURCE_PLATFORM_VERSION = "x-source-platform-version";
-	const SDK_VERSION = "2.0.0";
+	const SDK_VERSION = "2.0.1";
 
 	const SOURCE = "x-source";
 	const INTEGRATION = "API";

--- a/src/phonepe/sdk/pg/payments/v2/models/request/MetaInfo.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/MetaInfo.php
@@ -112,7 +112,7 @@ class MetaInfo implements \JsonSerializable
 
 	private function validateUdf1To10(string $field, ?string $value): void
 	{
-		if ($value !== null && strlen($value) > self::UDF1_TO_10_MAX_LENGTH) {
+		if ($value !== null && mb_strlen($value, 'UTF-8') > self::UDF1_TO_10_MAX_LENGTH) {
 			throw new \InvalidArgumentException(
 				"{$field} must not exceed " . self::UDF1_TO_10_MAX_LENGTH . " characters"
 			);
@@ -125,7 +125,7 @@ class MetaInfo implements \JsonSerializable
 			return;
 		}
 
-		if (strlen($value) > self::UDF11_TO_15_MAX_LENGTH) {
+		if (mb_strlen($value, 'UTF-8') > self::UDF11_TO_15_MAX_LENGTH) {
 			throw new \InvalidArgumentException(
 				"{$field} must not exceed " . self::UDF11_TO_15_MAX_LENGTH . " characters"
 			);

--- a/src/phonepe/sdk/pg/payments/v2/models/request/MetaInfo.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/MetaInfo.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+
+namespace PhonePe\payments\v2\models\request;
+
+class MetaInfo implements \JsonSerializable
+{
+	private ?string $udf1;
+	private ?string $udf2;
+	private ?string $udf3;
+	private ?string $udf4;
+	private ?string $udf5;
+	private ?string $udf6;
+	private ?string $udf7;
+	private ?string $udf8;
+	private ?string $udf9;
+	private ?string $udf10;
+	private ?string $udf11;
+	private ?string $udf12;
+	private ?string $udf13;
+	private ?string $udf14;
+	private ?string $udf15;
+
+	private const UDF1_TO_10_MAX_LENGTH = 256;
+	private const UDF11_TO_15_MAX_LENGTH = 50;
+	private const UDF11_TO_15_PATTERN = '/^[a-zA-Z0-9_\- @.+]*$/';
+
+	/**
+	 * @param string|null $udf1
+	 * @param string|null $udf2
+	 * @param string|null $udf3
+	 * @param string|null $udf4
+	 * @param string|null $udf5
+	 * @param string|null $udf6
+	 * @param string|null $udf7
+	 * @param string|null $udf8
+	 * @param string|null $udf9
+	 * @param string|null $udf10
+	 * @param string|null $udf11
+	 * @param string|null $udf12
+	 * @param string|null $udf13
+	 * @param string|null $udf14
+	 * @param string|null $udf15
+	 * @throws \InvalidArgumentException
+	 */
+	public function __construct(
+		?string $udf1 = null,
+		?string $udf2 = null,
+		?string $udf3 = null,
+		?string $udf4 = null,
+		?string $udf5 = null,
+		?string $udf6 = null,
+		?string $udf7 = null,
+		?string $udf8 = null,
+		?string $udf9 = null,
+		?string $udf10 = null,
+		?string $udf11 = null,
+		?string $udf12 = null,
+		?string $udf13 = null,
+		?string $udf14 = null,
+		?string $udf15 = null
+	) {
+		$this->validateUdf1To10('udf1', $udf1);
+		$this->validateUdf1To10('udf2', $udf2);
+		$this->validateUdf1To10('udf3', $udf3);
+		$this->validateUdf1To10('udf4', $udf4);
+		$this->validateUdf1To10('udf5', $udf5);
+		$this->validateUdf1To10('udf6', $udf6);
+		$this->validateUdf1To10('udf7', $udf7);
+		$this->validateUdf1To10('udf8', $udf8);
+		$this->validateUdf1To10('udf9', $udf9);
+		$this->validateUdf1To10('udf10', $udf10);
+
+		$this->validateUdf11To15('udf11', $udf11);
+		$this->validateUdf11To15('udf12', $udf12);
+		$this->validateUdf11To15('udf13', $udf13);
+		$this->validateUdf11To15('udf14', $udf14);
+		$this->validateUdf11To15('udf15', $udf15);
+
+		$this->udf1 = $udf1;
+		$this->udf2 = $udf2;
+		$this->udf3 = $udf3;
+		$this->udf4 = $udf4;
+		$this->udf5 = $udf5;
+		$this->udf6 = $udf6;
+		$this->udf7 = $udf7;
+		$this->udf8 = $udf8;
+		$this->udf9 = $udf9;
+		$this->udf10 = $udf10;
+		$this->udf11 = $udf11;
+		$this->udf12 = $udf12;
+		$this->udf13 = $udf13;
+		$this->udf14 = $udf14;
+		$this->udf15 = $udf15;
+	}
+
+	private function validateUdf1To10(string $field, ?string $value): void
+	{
+		if ($value !== null && strlen($value) > self::UDF1_TO_10_MAX_LENGTH) {
+			throw new \InvalidArgumentException(
+				"{$field} must not exceed " . self::UDF1_TO_10_MAX_LENGTH . " characters"
+			);
+		}
+	}
+
+	private function validateUdf11To15(string $field, ?string $value): void
+	{
+		if ($value === null) {
+			return;
+		}
+
+		if (strlen($value) > self::UDF11_TO_15_MAX_LENGTH) {
+			throw new \InvalidArgumentException(
+				"{$field} must not exceed " . self::UDF11_TO_15_MAX_LENGTH . " characters"
+			);
+		}
+
+		if (!preg_match(self::UDF11_TO_15_PATTERN, $value)) {
+			throw new \InvalidArgumentException(
+				"{$field} contains invalid characters; only alphanumeric, _, -, space, @, ., + are allowed"
+			);
+		}
+	}
+
+	public function jsonSerialize(): array
+	{
+		$result = [];
+
+		if ($this->udf1 !== null) $result['udf1'] = $this->udf1;
+		if ($this->udf2 !== null) $result['udf2'] = $this->udf2;
+		if ($this->udf3 !== null) $result['udf3'] = $this->udf3;
+		if ($this->udf4 !== null) $result['udf4'] = $this->udf4;
+		if ($this->udf5 !== null) $result['udf5'] = $this->udf5;
+		if ($this->udf6 !== null) $result['udf6'] = $this->udf6;
+		if ($this->udf7 !== null) $result['udf7'] = $this->udf7;
+		if ($this->udf8 !== null) $result['udf8'] = $this->udf8;
+		if ($this->udf9 !== null) $result['udf9'] = $this->udf9;
+		if ($this->udf10 !== null) $result['udf10'] = $this->udf10;
+		if ($this->udf11 !== null) $result['udf11'] = $this->udf11;
+		if ($this->udf12 !== null) $result['udf12'] = $this->udf12;
+		if ($this->udf13 !== null) $result['udf13'] = $this->udf13;
+		if ($this->udf14 !== null) $result['udf14'] = $this->udf14;
+		if ($this->udf15 !== null) $result['udf15'] = $this->udf15;
+
+		return $result;
+	}
+
+	public function getUdf1(): ?string
+	{
+		return $this->udf1;
+	}
+
+	public function getUdf2(): ?string
+	{
+		return $this->udf2;
+	}
+
+	public function getUdf3(): ?string
+	{
+		return $this->udf3;
+	}
+
+	public function getUdf4(): ?string
+	{
+		return $this->udf4;
+	}
+
+	public function getUdf5(): ?string
+	{
+		return $this->udf5;
+	}
+
+	public function getUdf6(): ?string
+	{
+		return $this->udf6;
+	}
+
+	public function getUdf7(): ?string
+	{
+		return $this->udf7;
+	}
+
+	public function getUdf8(): ?string
+	{
+		return $this->udf8;
+	}
+
+	public function getUdf9(): ?string
+	{
+		return $this->udf9;
+	}
+
+	public function getUdf10(): ?string
+	{
+		return $this->udf10;
+	}
+
+	public function getUdf11(): ?string
+	{
+		return $this->udf11;
+	}
+
+	public function getUdf12(): ?string
+	{
+		return $this->udf12;
+	}
+
+	public function getUdf13(): ?string
+	{
+		return $this->udf13;
+	}
+
+	public function getUdf14(): ?string
+	{
+		return $this->udf14;
+	}
+
+	public function getUdf15(): ?string
+	{
+		return $this->udf15;
+	}
+}

--- a/src/phonepe/sdk/pg/payments/v2/models/request/PrefillUserLoginDetails.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/PrefillUserLoginDetails.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+
+namespace PhonePe\payments\v2\models\request;
+
+class PrefillUserLoginDetails implements \JsonSerializable
+{
+	private ?string $phoneNumber;
+
+	/**
+	 * @param string|null $phoneNumber The user's mobile number to pre-fill on the PhonePe payment page.
+	 *                                 Expected format: 10-digit Indian mobile number (e.g. "9876543210"),
+	 *                                 or E.164 format with country code (e.g. "+919876543210").
+	 */
+	public function __construct(?string $phoneNumber = null)
+	{
+		$this->phoneNumber = $phoneNumber;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getPhoneNumber(): ?string
+	{
+		return $this->phoneNumber;
+	}
+
+	public function jsonSerialize(): array
+	{
+		$result = [];
+		if ($this->phoneNumber !== null) {
+			$result['phoneNumber'] = $this->phoneNumber;
+		}
+		return $result;
+	}
+}

--- a/src/phonepe/sdk/pg/payments/v2/models/request/StandardCheckoutPayRequest.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/StandardCheckoutPayRequest.php
@@ -25,19 +25,22 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 	private int $amount;
 	private $metaInfo;
 	private array $paymentFlow;
+	private ?PrefillUserLoginDetails $prefillUserLoginDetails;
 
 	/**
 	 * @param string $merchantOrderId
 	 * @param int $amount
 	 * @param $metaInfo
 	 * @param array $paymentFlow
+	 * @param PrefillUserLoginDetails|null $prefillUserLoginDetails
 	 */
-	public function __construct($merchantOrderId, $amount, $metaInfo, $paymentFlow)
+	public function __construct($merchantOrderId, $amount, $metaInfo, $paymentFlow, ?PrefillUserLoginDetails $prefillUserLoginDetails = null)
 	{
 		$this->merchantOrderId = $merchantOrderId;
 		$this->amount = $amount;
 		$this->metaInfo = $metaInfo;
 		$this->paymentFlow = $paymentFlow;
+		$this->prefillUserLoginDetails = $prefillUserLoginDetails;
 	}
 
 	/**
@@ -73,11 +76,28 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 	}
 
 	/**
+	 * @return PrefillUserLoginDetails|null
+	 */
+	public function getPrefillUserLoginDetails(): ?PrefillUserLoginDetails
+	{
+		return $this->prefillUserLoginDetails;
+	}
+
+	/**
 	 * @return array
 	 */
 	public function jsonSerialize(): array
 	{
-		return get_object_vars($this);
+		$result = [
+			'merchantOrderId' => $this->merchantOrderId,
+			'amount' => $this->amount,
+			'metaInfo' => $this->metaInfo,
+			'paymentFlow' => $this->paymentFlow,
+		];
+		if ($this->prefillUserLoginDetails !== null) {
+			$result['prefillUserLoginDetails'] = $this->prefillUserLoginDetails;
+		}
+		return $result;
 	}
 
 

--- a/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
@@ -19,8 +19,8 @@
 
 namespace PhonePe\payments\v2\models\request\builders;
 
+use PhonePe\payments\v2\models\request\MetaInfo;
 use PhonePe\payments\v2\models\request\StandardCheckoutPayRequest;
-use PhonePe\payments\v2\models\response\ResponseComponents\MetaInfo;
 use PhonePe\payments\v2\standardCheckout\StandardCheckoutConstants;
 
 class StandardCheckoutPayRequestBuilder
@@ -31,7 +31,21 @@ class StandardCheckoutPayRequestBuilder
 	private string $message;
 	private string $redirectUrl;
 
-	private $metaInfo;
+	private ?string $udf1 = null;
+	private ?string $udf2 = null;
+	private ?string $udf3 = null;
+	private ?string $udf4 = null;
+	private ?string $udf5 = null;
+	private ?string $udf6 = null;
+	private ?string $udf7 = null;
+	private ?string $udf8 = null;
+	private ?string $udf9 = null;
+	private ?string $udf10 = null;
+	private ?string $udf11 = null;
+	private ?string $udf12 = null;
+	private ?string $udf13 = null;
+	private ?string $udf14 = null;
+	private ?string $udf15 = null;
 
 	/**
 	 * @param string $merchantOrderId
@@ -74,27 +88,77 @@ class StandardCheckoutPayRequestBuilder
 	}
 
 	public function udf1($udf1): StandardCheckoutPayRequestBuilder{
-		$this->metaInfo['udf1'] = $udf1;
+		$this->udf1 = $udf1;
 		return $this;
 	}
 
 	public function udf2($udf2): StandardCheckoutPayRequestBuilder{
-		$this->metaInfo['udf2'] = $udf2;
+		$this->udf2 = $udf2;
 		return $this;
 	}
 
 	public function udf3($udf3): StandardCheckoutPayRequestBuilder{
-		$this->metaInfo['udf3'] = $udf3;
+		$this->udf3 = $udf3;
 		return $this;
 	}
 
 	public function udf4($udf4): StandardCheckoutPayRequestBuilder{
-		$this->metaInfo['udf4'] = $udf4;
+		$this->udf4 = $udf4;
 		return $this;
 	}
 
 	public function udf5($udf5): StandardCheckoutPayRequestBuilder{
-		$this->metaInfo['udf5'] = $udf5;
+		$this->udf5 = $udf5;
+		return $this;
+	}
+
+	public function udf6($udf6): StandardCheckoutPayRequestBuilder{
+		$this->udf6 = $udf6;
+		return $this;
+	}
+
+	public function udf7($udf7): StandardCheckoutPayRequestBuilder{
+		$this->udf7 = $udf7;
+		return $this;
+	}
+
+	public function udf8($udf8): StandardCheckoutPayRequestBuilder{
+		$this->udf8 = $udf8;
+		return $this;
+	}
+
+	public function udf9($udf9): StandardCheckoutPayRequestBuilder{
+		$this->udf9 = $udf9;
+		return $this;
+	}
+
+	public function udf10($udf10): StandardCheckoutPayRequestBuilder{
+		$this->udf10 = $udf10;
+		return $this;
+	}
+
+	public function udf11($udf11): StandardCheckoutPayRequestBuilder{
+		$this->udf11 = $udf11;
+		return $this;
+	}
+
+	public function udf12($udf12): StandardCheckoutPayRequestBuilder{
+		$this->udf12 = $udf12;
+		return $this;
+	}
+
+	public function udf13($udf13): StandardCheckoutPayRequestBuilder{
+		$this->udf13 = $udf13;
+		return $this;
+	}
+
+	public function udf14($udf14): StandardCheckoutPayRequestBuilder{
+		$this->udf14 = $udf14;
+		return $this;
+	}
+
+	public function udf15($udf15): StandardCheckoutPayRequestBuilder{
+		$this->udf15 = $udf15;
 		return $this;
 	}
 
@@ -116,10 +180,28 @@ class StandardCheckoutPayRequestBuilder
 		$paymentFlow["message"] = $this->message;
 		$paymentFlow["merchantUrls"]["redirectUrl"] = $this->redirectUrl;
 
+		$metaInfo = new MetaInfo(
+			$this->udf1,
+			$this->udf2,
+			$this->udf3,
+			$this->udf4,
+			$this->udf5,
+			$this->udf6,
+			$this->udf7,
+			$this->udf8,
+			$this->udf9,
+			$this->udf10,
+			$this->udf11,
+			$this->udf12,
+			$this->udf13,
+			$this->udf14,
+			$this->udf15
+		);
+
 		return new StandardCheckoutPayRequest(
 			$this->merchantOrderId,
 			$this->amount,
-			$this->metaInfo,
+			$metaInfo,
 			$paymentFlow
 		);
 	}

--- a/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
@@ -20,6 +20,7 @@
 namespace PhonePe\payments\v2\models\request\builders;
 
 use PhonePe\payments\v2\models\request\MetaInfo;
+use PhonePe\payments\v2\models\request\PrefillUserLoginDetails;
 use PhonePe\payments\v2\models\request\StandardCheckoutPayRequest;
 use PhonePe\payments\v2\standardCheckout\StandardCheckoutConstants;
 
@@ -46,6 +47,7 @@ class StandardCheckoutPayRequestBuilder
 	private ?string $udf13 = null;
 	private ?string $udf14 = null;
 	private ?string $udf15 = null;
+	private ?PrefillUserLoginDetails $prefillUserLoginDetails = null;
 
 	/**
 	 * @param string $merchantOrderId
@@ -163,6 +165,16 @@ class StandardCheckoutPayRequestBuilder
 	}
 
 	/**
+	 * @param PrefillUserLoginDetails $prefillUserLoginDetails
+	 * @return $this
+	 */
+	public function prefillUserLoginDetails(PrefillUserLoginDetails $prefillUserLoginDetails): StandardCheckoutPayRequestBuilder
+	{
+		$this->prefillUserLoginDetails = $prefillUserLoginDetails;
+		return $this;
+	}
+
+	/**
 	 * @return StandardCheckoutPayRequestBuilder
 	 */
 	public static function builder(): StandardCheckoutPayRequestBuilder
@@ -202,7 +214,8 @@ class StandardCheckoutPayRequestBuilder
 			$this->merchantOrderId,
 			$this->amount,
 			$metaInfo,
-			$paymentFlow
+			$paymentFlow,
+			$this->prefillUserLoginDetails
 		);
 	}
 

--- a/src/phonepe/sdk/pg/payments/v2/models/response/ResponseComponents/MetaInfo.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/response/ResponseComponents/MetaInfo.php
@@ -54,7 +54,7 @@ class MetaInfo
 	 * @param string|null $udf14
 	 * @param string|null $udf15
 	 */
-	public function __construct(string $udf1 = null, string $udf2 = null, string $udf3 = null, string $udf4 = null, string $udf5 = null, string $udf6 = null, string $udf7 = null, string $udf8 = null, string $udf9 = null, string $udf10 = null, string $udf11 = null, string $udf12 = null, string $udf13 = null, string $udf14 = null, string $udf15 = null)
+	public function __construct(?string $udf1 = null, ?string $udf2 = null, ?string $udf3 = null, ?string $udf4 = null, ?string $udf5 = null, ?string $udf6 = null, ?string $udf7 = null, ?string $udf8 = null, ?string $udf9 = null, ?string $udf10 = null, ?string $udf11 = null, ?string $udf12 = null, ?string $udf13 = null, ?string $udf14 = null, ?string $udf15 = null)
 	{
 		$this->udf1 = $udf1;
 		$this->udf2 = $udf2;

--- a/src/phonepe/sdk/pg/payments/v2/models/response/ResponseComponents/MetaInfo.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/response/ResponseComponents/MetaInfo.php
@@ -26,6 +26,16 @@ class MetaInfo
 	public $udf3;
 	public $udf4;
 	public $udf5;
+	public $udf6;
+	public $udf7;
+	public $udf8;
+	public $udf9;
+	public $udf10;
+	public $udf11;
+	public $udf12;
+	public $udf13;
+	public $udf14;
+	public $udf15;
 
 	/**
 	 * @param string|null $udf1
@@ -33,14 +43,34 @@ class MetaInfo
 	 * @param string|null $udf3
 	 * @param string|null $udf4
 	 * @param string|null $udf5
+	 * @param string|null $udf6
+	 * @param string|null $udf7
+	 * @param string|null $udf8
+	 * @param string|null $udf9
+	 * @param string|null $udf10
+	 * @param string|null $udf11
+	 * @param string|null $udf12
+	 * @param string|null $udf13
+	 * @param string|null $udf14
+	 * @param string|null $udf15
 	 */
-	public function __construct(string $udf1 = null, string $udf2 = null, string $udf3 = null, string $udf4 = null, string $udf5 = null)
+	public function __construct(string $udf1 = null, string $udf2 = null, string $udf3 = null, string $udf4 = null, string $udf5 = null, string $udf6 = null, string $udf7 = null, string $udf8 = null, string $udf9 = null, string $udf10 = null, string $udf11 = null, string $udf12 = null, string $udf13 = null, string $udf14 = null, string $udf15 = null)
 	{
 		$this->udf1 = $udf1;
 		$this->udf2 = $udf2;
 		$this->udf3 = $udf3;
 		$this->udf4 = $udf4;
 		$this->udf5 = $udf5;
+		$this->udf6 = $udf6;
+		$this->udf7 = $udf7;
+		$this->udf8 = $udf8;
+		$this->udf9 = $udf9;
+		$this->udf10 = $udf10;
+		$this->udf11 = $udf11;
+		$this->udf12 = $udf12;
+		$this->udf13 = $udf13;
+		$this->udf14 = $udf14;
+		$this->udf15 = $udf15;
 	}
 
 	public function getUdf1(): ?string
@@ -66,6 +96,56 @@ class MetaInfo
 	public function getUdf5(): ?string
 	{
 		return $this->udf5;
+	}
+
+	public function getUdf6(): ?string
+	{
+		return $this->udf6;
+	}
+
+	public function getUdf7(): ?string
+	{
+		return $this->udf7;
+	}
+
+	public function getUdf8(): ?string
+	{
+		return $this->udf8;
+	}
+
+	public function getUdf9(): ?string
+	{
+		return $this->udf9;
+	}
+
+	public function getUdf10(): ?string
+	{
+		return $this->udf10;
+	}
+
+	public function getUdf11(): ?string
+	{
+		return $this->udf11;
+	}
+
+	public function getUdf12(): ?string
+	{
+		return $this->udf12;
+	}
+
+	public function getUdf13(): ?string
+	{
+		return $this->udf13;
+	}
+
+	public function getUdf14(): ?string
+	{
+		return $this->udf14;
+	}
+
+	public function getUdf15(): ?string
+	{
+		return $this->udf15;
 	}
 
 

--- a/tests/Integration/PaymentWorkflowIntegrationTest.php
+++ b/tests/Integration/PaymentWorkflowIntegrationTest.php
@@ -234,7 +234,7 @@ class PaymentWorkflowIntegrationTest extends BaseTestCase
         }
     }
     
-    public function paymentAmountProvider(): array
+    public static function paymentAmountProvider(): array
     {
         return [
             [1, 'Minimum amount'],

--- a/tests/Unit/payments/v2/models/request/MetaInfoTest.php
+++ b/tests/Unit/payments/v2/models/request/MetaInfoTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+namespace Tests\Unit\payments\v2\models\request;
+
+use InvalidArgumentException;
+use PhonePe\payments\v2\models\request\MetaInfo;
+use Tests\Unit\BaseTestCase;
+
+class MetaInfoTest extends BaseTestCase
+{
+    // -------------------------------------------------------------------------
+    // Constructor and getters
+    // -------------------------------------------------------------------------
+
+    public function testConstructorSetsAllFifteenFields(): void
+    {
+        $metaInfo = new MetaInfo(
+            'v1', 'v2', 'v3', 'v4', 'v5',
+            'v6', 'v7', 'v8', 'v9', 'v10',
+            'v11', 'v12', 'v13', 'v14', 'v15'
+        );
+
+        $this->assertEquals('v1',  $metaInfo->getUdf1());
+        $this->assertEquals('v2',  $metaInfo->getUdf2());
+        $this->assertEquals('v3',  $metaInfo->getUdf3());
+        $this->assertEquals('v4',  $metaInfo->getUdf4());
+        $this->assertEquals('v5',  $metaInfo->getUdf5());
+        $this->assertEquals('v6',  $metaInfo->getUdf6());
+        $this->assertEquals('v7',  $metaInfo->getUdf7());
+        $this->assertEquals('v8',  $metaInfo->getUdf8());
+        $this->assertEquals('v9',  $metaInfo->getUdf9());
+        $this->assertEquals('v10', $metaInfo->getUdf10());
+        $this->assertEquals('v11', $metaInfo->getUdf11());
+        $this->assertEquals('v12', $metaInfo->getUdf12());
+        $this->assertEquals('v13', $metaInfo->getUdf13());
+        $this->assertEquals('v14', $metaInfo->getUdf14());
+        $this->assertEquals('v15', $metaInfo->getUdf15());
+    }
+
+    public function testDefaultConstructorSetsAllFieldsToNull(): void
+    {
+        $metaInfo = new MetaInfo();
+
+        for ($i = 1; $i <= 15; $i++) {
+            $getter = 'getUdf' . $i;
+            $this->assertNull($metaInfo->$getter(), "getUdf{$i}() should return null by default");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // jsonSerialize — omits null fields
+    // -------------------------------------------------------------------------
+
+    public function testJsonSerializeOmitsNullFields(): void
+    {
+        $metaInfo = new MetaInfo('hello', null, null, null, 'world');
+
+        $serialized = $metaInfo->jsonSerialize();
+
+        $this->assertArrayHasKey('udf1', $serialized);
+        $this->assertArrayHasKey('udf5', $serialized);
+        $this->assertEquals('hello', $serialized['udf1']);
+        $this->assertEquals('world', $serialized['udf5']);
+
+        $this->assertArrayNotHasKey('udf2', $serialized);
+        $this->assertArrayNotHasKey('udf3', $serialized);
+        $this->assertArrayNotHasKey('udf4', $serialized);
+        $this->assertArrayNotHasKey('udf6', $serialized);
+    }
+
+    public function testJsonSerializeReturnsEmptyArrayWhenAllNull(): void
+    {
+        $metaInfo = new MetaInfo();
+
+        $this->assertSame([], $metaInfo->jsonSerialize());
+    }
+
+    public function testJsonSerializeIncludesOnlySetFields(): void
+    {
+        $metaInfo = new MetaInfo(
+            null, null, null, null, null,
+            null, null, null, null, null,
+            'tag1'
+        );
+
+        $serialized = $metaInfo->jsonSerialize();
+
+        $this->assertCount(1, $serialized);
+        $this->assertArrayHasKey('udf11', $serialized);
+        $this->assertEquals('tag1', $serialized['udf11']);
+    }
+
+    // -------------------------------------------------------------------------
+    // udf1–udf10: max length 256
+    // -------------------------------------------------------------------------
+
+    public function testUdf1AcceptsExactly256Chars(): void
+    {
+        $value = str_repeat('A', 256);
+        $metaInfo = new MetaInfo($value);
+        $this->assertEquals($value, $metaInfo->getUdf1());
+    }
+
+    public function testUdf1RejectsOver256Chars(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/udf1/');
+        $this->expectExceptionMessageMatches('/256/');
+
+        new MetaInfo(str_repeat('A', 257));
+    }
+
+    public function testUdf5AcceptsExactly256Chars(): void
+    {
+        $value = str_repeat('B', 256);
+        $metaInfo = new MetaInfo(null, null, null, null, $value);
+        $this->assertEquals($value, $metaInfo->getUdf5());
+    }
+
+    public function testUdf5RejectsOver256Chars(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/udf5/');
+        $this->expectExceptionMessageMatches('/256/');
+
+        new MetaInfo(null, null, null, null, str_repeat('B', 257));
+    }
+
+    /** @dataProvider udf6To10Provider */
+    public function testUdf6To10RejectOver256Chars(int $udfNum): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/udf{$udfNum}/");
+        $this->expectExceptionMessageMatches('/256/');
+
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = str_repeat('X', 257);
+        new MetaInfo(...$args);
+    }
+
+    public static function udf6To10Provider(): array
+    {
+        return [
+            'udf6'  => [6],
+            'udf7'  => [7],
+            'udf8'  => [8],
+            'udf9'  => [9],
+            'udf10' => [10],
+        ];
+    }
+
+    /** @dataProvider udf6To10Provider */
+    public function testUdf6To10AcceptExactly256Chars(int $udfNum): void
+    {
+        $value = str_repeat('Y', 256);
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = $value;
+        $metaInfo = new MetaInfo(...$args);
+
+        $getter = 'getUdf' . $udfNum;
+        $this->assertEquals($value, $metaInfo->$getter());
+    }
+
+    // -------------------------------------------------------------------------
+    // udf11–udf15: max length 50
+    // -------------------------------------------------------------------------
+
+    /** @dataProvider udf11To15Provider */
+    public function testUdf11To15AcceptExactly50Chars(int $udfNum): void
+    {
+        $value = str_repeat('a', 50);
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = $value;
+        $metaInfo = new MetaInfo(...$args);
+
+        $getter = 'getUdf' . $udfNum;
+        $this->assertEquals($value, $metaInfo->$getter());
+    }
+
+    /** @dataProvider udf11To15Provider */
+    public function testUdf11To15RejectOver50Chars(int $udfNum): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/udf{$udfNum}/");
+        $this->expectExceptionMessageMatches('/50/');
+
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = str_repeat('a', 51);
+        new MetaInfo(...$args);
+    }
+
+    public static function udf11To15Provider(): array
+    {
+        return [
+            'udf11' => [11],
+            'udf12' => [12],
+            'udf13' => [13],
+            'udf14' => [14],
+            'udf15' => [15],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // udf11–udf15: character validation
+    // -------------------------------------------------------------------------
+
+    /** @dataProvider invalidCharProvider */
+    public function testUdf11To15RejectInvalidChars(int $udfNum, string $invalidValue): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/udf{$udfNum}/");
+
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = $invalidValue;
+        new MetaInfo(...$args);
+    }
+
+    public static function invalidCharProvider(): array
+    {
+        $cases = [];
+        foreach ([11, 12, 13, 14, 15] as $n) {
+            $cases["udf{$n} with !"  ] = [$n, 'invalid!'];
+            $cases["udf{$n} with #"  ] = [$n, 'invalid#'];
+            $cases["udf{$n} with \$" ] = [$n, 'invalid$'];
+        }
+        return $cases;
+    }
+
+    /** @dataProvider validCharProvider */
+    public function testUdf11To15AllowValidChars(int $udfNum, string $validValue): void
+    {
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = $validValue;
+        $metaInfo = new MetaInfo(...$args);
+
+        $getter = 'getUdf' . $udfNum;
+        $this->assertEquals($validValue, $metaInfo->$getter());
+    }
+
+    public static function validCharProvider(): array
+    {
+        return [
+            'udf11 alphanumeric'  => [11, 'abc123'],
+            'udf11 underscore'    => [11, 'my_tag'],
+            'udf11 hyphen'        => [11, 'my-tag'],
+            'udf11 space'         => [11, 'my tag'],
+            'udf11 at'            => [11, 'user@host'],
+            'udf11 dot'           => [11, 'file.txt'],
+            'udf11 plus'          => [11, 'a+b'],
+            'udf12 mixed valid'   => [12, 'Tag_1 @home.+end'],
+            'udf15 all valid chars' => [15, 'aZ0_ -.@+'],
+        ];
+    }
+
+    /** @dataProvider udf11To15Provider */
+    public function testUdf11To15AllowEmptyString(int $udfNum): void
+    {
+        $args = array_fill(0, 15, null);
+        $args[$udfNum - 1] = '';
+        $metaInfo = new MetaInfo(...$args);
+
+        $getter = 'getUdf' . $udfNum;
+        $this->assertSame('', $metaInfo->$getter());
+    }
+
+    /** @dataProvider udf11To15Provider */
+    public function testUdf11To15AllowNull(int $udfNum): void
+    {
+        $args = array_fill(0, 15, null);
+        $metaInfo = new MetaInfo(...$args);
+
+        $getter = 'getUdf' . $udfNum;
+        $this->assertNull($metaInfo->$getter());
+    }
+
+    // -------------------------------------------------------------------------
+    // udf1–udf10 allow special characters that udf11–udf15 would reject
+    // -------------------------------------------------------------------------
+
+    public function testUdf1To10AllowSpecialCharsInvalidForUdf11To15(): void
+    {
+        $specialValue = 'chars!#$%^&*()';
+
+        $metaInfo = new MetaInfo(
+            $specialValue, $specialValue, $specialValue, $specialValue, $specialValue,
+            $specialValue, $specialValue, $specialValue, $specialValue, $specialValue
+        );
+
+        for ($i = 1; $i <= 10; $i++) {
+            $getter = 'getUdf' . $i;
+            $this->assertEquals($specialValue, $metaInfo->$getter(), "udf{$i} should allow special chars");
+        }
+    }
+}

--- a/tests/Unit/payments/v2/models/request/MetaInfoTest.php
+++ b/tests/Unit/payments/v2/models/request/MetaInfoTest.php
@@ -290,6 +290,27 @@ class MetaInfoTest extends BaseTestCase
     }
 
     // -------------------------------------------------------------------------
+    // udf1–udf10: multibyte / UTF-8 character counting
+    // -------------------------------------------------------------------------
+
+    public function testUdf1AcceptsExactly256MultiBytechars(): void
+    {
+        // 256 emoji = 256 characters but 1024 bytes — must be accepted
+        $value = str_repeat('🎉', 256);
+        $metaInfo = new MetaInfo($value);
+        $this->assertEquals($value, $metaInfo->getUdf1());
+    }
+
+    public function testUdf1Rejects257MultiBytechars(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/udf1/');
+        $this->expectExceptionMessageMatches('/256/');
+
+        new MetaInfo(str_repeat('🎉', 257));
+    }
+
+    // -------------------------------------------------------------------------
     // udf1–udf10 allow special characters that udf11–udf15 would reject
     // -------------------------------------------------------------------------
 

--- a/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
+++ b/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
@@ -20,6 +20,7 @@ namespace Tests\Unit\payments\v2\models\request\builders;
 
 use PhonePe\payments\v2\models\request\builders\StandardCheckoutPayRequestBuilder;
 use PhonePe\payments\v2\models\request\MetaInfo;
+use PhonePe\payments\v2\models\request\PrefillUserLoginDetails;
 use PhonePe\payments\v2\models\request\StandardCheckoutPayRequest;
 use PhonePe\payments\v2\standardCheckout\StandardCheckoutConstants;
 use Tests\Fixtures\TestDataProvider;
@@ -248,5 +249,82 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         
         $metaInfo = $request->getMetaInfo();
         $this->assertEquals($longUdf, $metaInfo->getUdf1());
+    }
+
+    public function testBuildPaymentRequestWithPrefillUserLoginDetails(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->prefillUserLoginDetails($prefillDetails)
+            ->build();
+
+        $this->assertInstanceOf(StandardCheckoutPayRequest::class, $request);
+        $retrieved = $request->getPrefillUserLoginDetails();
+        $this->assertInstanceOf(PrefillUserLoginDetails::class, $retrieved);
+        $this->assertEquals('9876543210', $retrieved->getPhoneNumber());
+    }
+
+    public function testPrefillUserLoginDetailsAbsentByDefault(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->build();
+
+        $this->assertNull($request->getPrefillUserLoginDetails());
+    }
+
+    public function testPrefillUserLoginDetailsOmittedFromJsonWhenNull(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->build();
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+        $this->assertArrayNotHasKey('prefillUserLoginDetails', $decoded);
+    }
+
+    public function testPrefillUserLoginDetailsPresentInJsonWhenSet(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->prefillUserLoginDetails($prefillDetails)
+            ->build();
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+        $this->assertArrayHasKey('prefillUserLoginDetails', $decoded);
+        $this->assertEquals('9876543210', $decoded['prefillUserLoginDetails']['phoneNumber']);
+    }
+
+    public function testPrefillUserLoginDetailsFluentInterface(): void
+    {
+        $builder = StandardCheckoutPayRequestBuilder::builder();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        $result = $builder->prefillUserLoginDetails($prefillDetails);
+        $this->assertSame($builder, $result);
     }
 }

--- a/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
+++ b/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
@@ -19,6 +19,7 @@
 namespace Tests\Unit\payments\v2\models\request\builders;
 
 use PhonePe\payments\v2\models\request\builders\StandardCheckoutPayRequestBuilder;
+use PhonePe\payments\v2\models\request\MetaInfo;
 use PhonePe\payments\v2\models\request\StandardCheckoutPayRequest;
 use PhonePe\payments\v2\standardCheckout\StandardCheckoutConstants;
 use Tests\Fixtures\TestDataProvider;
@@ -65,9 +66,9 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         $this->assertInstanceOf(StandardCheckoutPayRequest::class, $request);
         
         $metaInfo = $request->getMetaInfo();
-        $this->assertIsArray($metaInfo);
-        $this->assertEquals($testData['metaInfo']['udf1'], $metaInfo['udf1']);
-        $this->assertEquals($testData['metaInfo']['udf2'], $metaInfo['udf2']);
+        $this->assertInstanceOf(MetaInfo::class, $metaInfo);
+        $this->assertEquals($testData['metaInfo']['udf1'], $metaInfo->getUdf1());
+        $this->assertEquals($testData['metaInfo']['udf2'], $metaInfo->getUdf2());
     }
 
     public function testBuildPaymentRequestWithAllUdfFields(): void
@@ -87,11 +88,11 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
             ->build();
 
         $metaInfo = $request->getMetaInfo();
-        $this->assertEquals('udf1_value', $metaInfo['udf1']);
-        $this->assertEquals('udf2_value', $metaInfo['udf2']);
-        $this->assertEquals('udf3_value', $metaInfo['udf3']);
-        $this->assertEquals('udf4_value', $metaInfo['udf4']);
-        $this->assertEquals('udf5_value', $metaInfo['udf5']);
+        $this->assertEquals('udf1_value', $metaInfo->getUdf1());
+        $this->assertEquals('udf2_value', $metaInfo->getUdf2());
+        $this->assertEquals('udf3_value', $metaInfo->getUdf3());
+        $this->assertEquals('udf4_value', $metaInfo->getUdf4());
+        $this->assertEquals('udf5_value', $metaInfo->getUdf5());
     }
 
     public function testPaymentFlowStructure(): void
@@ -196,9 +197,10 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
             ->redirectUrl($testData['redirectUrl'])
             ->build();
 
-        // Meta info should be null or empty when no UDF fields are set
+        // MetaInfo is always created; with no UDF fields set all getters return null
         $metaInfo = $request->getMetaInfo();
-        $this->assertTrue(is_null($metaInfo) || (is_array($metaInfo) && empty($metaInfo)));
+        $this->assertInstanceOf(MetaInfo::class, $metaInfo);
+        $this->assertNull($metaInfo->getUdf1());
     }
 
     public function testSpecialCharactersInFields(): void
@@ -221,7 +223,7 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         $this->assertEquals($specialUrl, $paymentFlow['merchantUrls']['redirectUrl']);
         
         $metaInfo = $request->getMetaInfo();
-        $this->assertEquals('UDF with émojis: 🎉💳', $metaInfo['udf1']);
+        $this->assertEquals('UDF with émojis: 🎉💳', $metaInfo->getUdf1());
     }
 
     public function testLongFieldValues(): void
@@ -229,7 +231,7 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         $longOrderId = str_repeat('A', 100);
         $longMessage = str_repeat('This is a very long payment message. ', 10);
         $longUrl = 'https://example.com/very-long-callback-url-' . str_repeat('param', 20);
-        $longUdf = str_repeat('Long UDF value ', 20);
+        $longUdf = str_repeat('A', 256); // exactly at the 256-char limit for udf1-udf10
         
         $request = StandardCheckoutPayRequestBuilder::builder()
             ->merchantOrderId($longOrderId)
@@ -245,6 +247,6 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         $this->assertEquals($longUrl, $paymentFlow['merchantUrls']['redirectUrl']);
         
         $metaInfo = $request->getMetaInfo();
-        $this->assertEquals($longUdf, $metaInfo['udf1']);
+        $this->assertEquals($longUdf, $metaInfo->getUdf1());
     }
 }

--- a/tests/Unit/payments/v2/models/response/ResponseComponents/MetaInfoTest.php
+++ b/tests/Unit/payments/v2/models/response/ResponseComponents/MetaInfoTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+namespace Tests\Unit\payments\v2\models\response\ResponseComponents;
+
+use PhonePe\payments\v2\models\response\ResponseComponents\MetaInfo;
+use Tests\Unit\BaseTestCase;
+
+class MetaInfoTest extends BaseTestCase
+{
+    public function testMetaInfoConstructorSetsAllFields(): void
+    {
+        $metaInfo = new MetaInfo(
+            'val1', 'val2', 'val3', 'val4', 'val5',
+            'val6', 'val7', 'val8', 'val9', 'val10',
+            'val11', 'val12', 'val13', 'val14', 'val15'
+        );
+
+        $this->assertEquals('val1', $metaInfo->getUdf1());
+        $this->assertEquals('val2', $metaInfo->getUdf2());
+        $this->assertEquals('val3', $metaInfo->getUdf3());
+        $this->assertEquals('val4', $metaInfo->getUdf4());
+        $this->assertEquals('val5', $metaInfo->getUdf5());
+        $this->assertEquals('val6', $metaInfo->getUdf6());
+        $this->assertEquals('val7', $metaInfo->getUdf7());
+        $this->assertEquals('val8', $metaInfo->getUdf8());
+        $this->assertEquals('val9', $metaInfo->getUdf9());
+        $this->assertEquals('val10', $metaInfo->getUdf10());
+        $this->assertEquals('val11', $metaInfo->getUdf11());
+        $this->assertEquals('val12', $metaInfo->getUdf12());
+        $this->assertEquals('val13', $metaInfo->getUdf13());
+        $this->assertEquals('val14', $metaInfo->getUdf14());
+        $this->assertEquals('val15', $metaInfo->getUdf15());
+    }
+
+    public function testMetaInfoDefaultsAllFieldsToNull(): void
+    {
+        $metaInfo = new MetaInfo();
+
+        $this->assertNull($metaInfo->getUdf1());
+        $this->assertNull($metaInfo->getUdf2());
+        $this->assertNull($metaInfo->getUdf3());
+        $this->assertNull($metaInfo->getUdf4());
+        $this->assertNull($metaInfo->getUdf5());
+        $this->assertNull($metaInfo->getUdf6());
+        $this->assertNull($metaInfo->getUdf7());
+        $this->assertNull($metaInfo->getUdf8());
+        $this->assertNull($metaInfo->getUdf9());
+        $this->assertNull($metaInfo->getUdf10());
+        $this->assertNull($metaInfo->getUdf11());
+        $this->assertNull($metaInfo->getUdf12());
+        $this->assertNull($metaInfo->getUdf13());
+        $this->assertNull($metaInfo->getUdf14());
+        $this->assertNull($metaInfo->getUdf15());
+    }
+
+    public function testMetaInfoHasUdf6ThroughUdf15(): void
+    {
+        $metaInfo = new MetaInfo();
+
+        for ($i = 6; $i <= 15; $i++) {
+            $this->assertTrue(
+                property_exists($metaInfo, 'udf' . $i),
+                "Property 'udf{$i}' should exist on MetaInfo"
+            );
+        }
+    }
+
+    public function testMetaInfoGettersReturnCorrectValues(): void
+    {
+        $metaInfo = new MetaInfo(
+            null, null, null, null, null,
+            null, null, null, null, null,
+            'udf11val', 'udf12val', 'udf13val', 'udf14val', 'udf15val'
+        );
+
+        $this->assertNull($metaInfo->getUdf6());
+        $this->assertNull($metaInfo->getUdf7());
+        $this->assertNull($metaInfo->getUdf8());
+        $this->assertNull($metaInfo->getUdf9());
+        $this->assertNull($metaInfo->getUdf10());
+        $this->assertEquals('udf11val', $metaInfo->getUdf11());
+        $this->assertEquals('udf12val', $metaInfo->getUdf12());
+        $this->assertEquals('udf13val', $metaInfo->getUdf13());
+        $this->assertEquals('udf14val', $metaInfo->getUdf14());
+        $this->assertEquals('udf15val', $metaInfo->getUdf15());
+    }
+}


### PR DESCRIPTION
- Expand MetaInfo from udf1-5 to udf1-15 with constructor params and getters
- Add MetaInfoTest with 4 tests covering all fields, null defaults, and getters
- Bump SDK_VERSION 2.0.0 -> 2.0.1
- Added PrefillUserLoginDetails support in standardcheckout