### PR TITLE
Customer details for checkout/v2/pay for PHP SDK

### DIFF
--- a/src/phonepe/sdk/pg/payments/v2/models/request/CustomerDetails.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/CustomerDetails.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+namespace PhonePe\payments\v2\models\request;
+
+class CustomerDetails implements \JsonSerializable
+{
+    private ?string $name;
+    private ?string $email;
+    private ?string $phoneNumber;
+
+    /**
+     * @param string|null $name        The full name of the customer.
+     * @param string|null $email       The verified email address of the customer.
+     * @param string|null $phoneNumber The mobile number of the customer.
+     */
+    public function __construct(?string $name = null, ?string $email = null, ?string $phoneNumber = null)
+    {
+       $this->name = $name;
+       $this->email = $email;
+       $this->phoneNumber = $phoneNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+       return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEmail(): ?string
+    {
+       return $this->email;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPhoneNumber(): ?string
+    {
+       return $this->phoneNumber;
+    }
+
+    public function jsonSerialize(): array
+    {
+       $result = [];
+
+       if ($this->name !== null) {
+          $result['name'] = $this->name;
+       }
+
+       if ($this->email !== null) {
+          $result['email'] = $this->email;
+       }
+
+       if ($this->phoneNumber !== null) {
+          $result['phoneNumber'] = $this->phoneNumber;
+       }
+
+       return $result;
+    }
+}

--- a/src/phonepe/sdk/pg/payments/v2/models/request/StandardCheckoutPayRequest.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/StandardCheckoutPayRequest.php
@@ -26,6 +26,7 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 	private $metaInfo;
 	private array $paymentFlow;
 	private ?PrefillUserLoginDetails $prefillUserLoginDetails;
+	private ?CustomerDetails $customerDetails;
 
 	/**
 	 * @param string $merchantOrderId
@@ -34,13 +35,14 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 	 * @param array $paymentFlow
 	 * @param PrefillUserLoginDetails|null $prefillUserLoginDetails
 	 */
-	public function __construct($merchantOrderId, $amount, $metaInfo, $paymentFlow, ?PrefillUserLoginDetails $prefillUserLoginDetails = null)
+	public function __construct($merchantOrderId, $amount, $metaInfo, $paymentFlow, ?PrefillUserLoginDetails $prefillUserLoginDetails = null, ?CustomerDetails $customerDetails = null)
 	{
 		$this->merchantOrderId = $merchantOrderId;
 		$this->amount = $amount;
 		$this->metaInfo = $metaInfo;
 		$this->paymentFlow = $paymentFlow;
 		$this->prefillUserLoginDetails = $prefillUserLoginDetails;
+		$this->customerDetails = $customerDetails;
 	}
 
 	/**
@@ -83,6 +85,14 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 		return $this->prefillUserLoginDetails;
 	}
 
+    /**
+     * @return CustomerDetails|null
+     */
+    public function getCustomerDetails(): ?CustomerDetails
+    {
+       return $this->customerDetails;
+    }
+
 	/**
 	 * @return array
 	 */
@@ -97,6 +107,9 @@ class StandardCheckoutPayRequest implements \JsonSerializable
 		if ($this->prefillUserLoginDetails !== null) {
 			$result['prefillUserLoginDetails'] = $this->prefillUserLoginDetails;
 		}
+        if ($this->customerDetails !== null) {
+            $result['customerDetails'] = $this->customerDetails;
+        }
 		return $result;
 	}
 

--- a/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
@@ -19,6 +19,7 @@
 
 namespace PhonePe\payments\v2\models\request\builders;
 
+use PhonePe\payments\v2\models\request\CustomerDetails;
 use PhonePe\payments\v2\models\request\MetaInfo;
 use PhonePe\payments\v2\models\request\PrefillUserLoginDetails;
 use PhonePe\payments\v2\models\request\StandardCheckoutPayRequest;
@@ -48,6 +49,7 @@ class StandardCheckoutPayRequestBuilder
 	private ?string $udf14 = null;
 	private ?string $udf15 = null;
 	private ?PrefillUserLoginDetails $prefillUserLoginDetails = null;
+	private ?CustomerDetails $customerDetails = null;
 
 	/**
 	 * @param string $merchantOrderId
@@ -165,12 +167,24 @@ class StandardCheckoutPayRequestBuilder
 	}
 
 	/**
-	 * @param PrefillUserLoginDetails $prefillUserLoginDetails
+	 * @param string|null $name        The full name of the customer.
+	 * @param string|null $email       The email address of the customer.
+	 * @param string|null $phoneNumber The mobile number of the customer.
 	 * @return $this
 	 */
-	public function prefillUserLoginDetails(PrefillUserLoginDetails $prefillUserLoginDetails): StandardCheckoutPayRequestBuilder
+	public function customerDetails(?string $name, ?string $email, ?string $phoneNumber): StandardCheckoutPayRequestBuilder
 	{
-		$this->prefillUserLoginDetails = $prefillUserLoginDetails;
+		$this->customerDetails = new CustomerDetails($name, $email, $phoneNumber);
+		return $this;
+	}
+
+	/**
+	 * @param string|null $phoneNumber The mobile number to pre-fill on the PhonePe payment page.
+	 * @return $this
+	 */
+	public function prefillUserLoginDetails(?string $phoneNumber): StandardCheckoutPayRequestBuilder
+	{
+		$this->prefillUserLoginDetails = new PrefillUserLoginDetails($phoneNumber);
 		return $this;
 	}
 
@@ -215,7 +229,8 @@ class StandardCheckoutPayRequestBuilder
 			$this->amount,
 			$metaInfo,
 			$paymentFlow,
-			$this->prefillUserLoginDetails
+			$this->prefillUserLoginDetails,
+			$this->customerDetails
 		);
 	}
 

--- a/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
+++ b/src/phonepe/sdk/pg/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilder.php
@@ -167,24 +167,22 @@ class StandardCheckoutPayRequestBuilder
 	}
 
 	/**
-	 * @param string|null $name        The full name of the customer.
-	 * @param string|null $email       The email address of the customer.
-	 * @param string|null $phoneNumber The mobile number of the customer.
+	 * @param CustomerDetails $customerDetails
 	 * @return $this
 	 */
-	public function customerDetails(?string $name, ?string $email, ?string $phoneNumber): StandardCheckoutPayRequestBuilder
+	public function customerDetails(CustomerDetails $customerDetails): StandardCheckoutPayRequestBuilder
 	{
-		$this->customerDetails = new CustomerDetails($name, $email, $phoneNumber);
+		$this->customerDetails = $customerDetails;
 		return $this;
 	}
 
 	/**
-	 * @param string|null $phoneNumber The mobile number to pre-fill on the PhonePe payment page.
+	 * @param PrefillUserLoginDetails $prefillUserLoginDetails
 	 * @return $this
 	 */
-	public function prefillUserLoginDetails(?string $phoneNumber): StandardCheckoutPayRequestBuilder
+	public function prefillUserLoginDetails(PrefillUserLoginDetails $prefillUserLoginDetails): StandardCheckoutPayRequestBuilder
 	{
-		$this->prefillUserLoginDetails = new PrefillUserLoginDetails($phoneNumber);
+		$this->prefillUserLoginDetails = $prefillUserLoginDetails;
 		return $this;
 	}
 

--- a/tests/Unit/payments/v2/models/request/CustomerDetailsTest.php
+++ b/tests/Unit/payments/v2/models/request/CustomerDetailsTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/*
+*  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+namespace Tests\Unit\payments\v2\models\request;
+
+use PhonePe\payments\v2\models\request\CustomerDetails;
+use Tests\Unit\BaseTestCase;
+use InvalidArgumentException;
+
+class CustomerDetailsTest extends BaseTestCase
+{
+    public function testCustomerDetailsWithValidData(): void
+    {
+        $customerDetails = new CustomerDetails(
+            'John Doe',
+            'john.doe@example.com',
+            '9876543210'
+        );
+
+        $this->assertEquals('John Doe', $customerDetails->getName());
+        $this->assertEquals('john.doe@example.com', $customerDetails->getEmail());
+        $this->assertEquals('9876543210', $customerDetails->getPhoneNumber());
+    }
+
+    public function testCustomerDetailsWithAllNullValues(): void
+    {
+        $customerDetails = new CustomerDetails(null, null, null);
+
+        $this->assertNull($customerDetails->getName());
+        $this->assertNull($customerDetails->getEmail());
+        $this->assertNull($customerDetails->getPhoneNumber());
+    }
+
+    public function testCustomerDetailsWithOnlyName(): void
+    {
+        $customerDetails = new CustomerDetails('John Doe', null, null);
+
+        $this->assertEquals('John Doe', $customerDetails->getName());
+        $this->assertNull($customerDetails->getEmail());
+        $this->assertNull($customerDetails->getPhoneNumber());
+    }
+
+    public function testCustomerDetailsWithOnlyEmail(): void
+    {
+        $customerDetails = new CustomerDetails(null, 'john@example.com', null);
+
+        $this->assertNull($customerDetails->getName());
+        $this->assertEquals('john@example.com', $customerDetails->getEmail());
+        $this->assertNull($customerDetails->getPhoneNumber());
+    }
+
+    public function testCustomerDetailsWithOnlyPhoneNumber(): void
+    {
+        $customerDetails = new CustomerDetails(null, null, '9876543210');
+
+        $this->assertNull($customerDetails->getName());
+        $this->assertNull($customerDetails->getEmail());
+        $this->assertEquals('9876543210', $customerDetails->getPhoneNumber());
+    }
+
+    /**
+     * @dataProvider validPhoneNumberProvider
+     */
+    public function testValidPhoneNumberFormats(string $phoneNumber): void
+    {
+        $customerDetails = new CustomerDetails(null, null, $phoneNumber);
+        $this->assertEquals($phoneNumber, $customerDetails->getPhoneNumber());
+    }
+
+    public static function validPhoneNumberProvider(): array
+    {
+        return [
+            'Indian 10-digit' => ['9876543210'],
+            'E.164 with +91' => ['+919876543210'],
+            'E.164 with +1' => ['+14155552671'],
+            'E.164 with +44' => ['+447911123456'],
+            '11-digit number' => ['12345678901'],
+            '15-digit number' => ['123456789012345'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidPhoneNumberProvider
+     */
+    public function testInvalidPhoneNumberFormats(string $phoneNumber, string $expectedMessage): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new CustomerDetails(null, null, $phoneNumber);
+    }
+
+    public static function invalidPhoneNumberProvider(): array
+    {
+        return [
+            'Too short' => [
+                '98765',
+                "Invalid phoneNumber '98765': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Too long' => [
+                '1234567890123456',
+                "Invalid phoneNumber '1234567890123456': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Contains letters' => [
+                '987654321a',
+                "Invalid phoneNumber '987654321a': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Contains spaces' => [
+                '98765 43210',
+                "Invalid phoneNumber '98765 43210': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Contains hyphens' => [
+                '9876-543-210',
+                "Invalid phoneNumber '9876-543-210': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Contains special chars' => [
+                '98765@43210',
+                "Invalid phoneNumber '98765@43210': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+            'Empty string' => [
+                '',
+                "Invalid phoneNumber '': expected a 10-digit number or E.164 format (e.g. '+919876543210')."
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validEmailProvider
+     */
+    public function testValidEmailFormats(string $email): void
+    {
+        $customerDetails = new CustomerDetails(null, $email, null);
+        $this->assertEquals($email, $customerDetails->getEmail());
+    }
+
+    public static function validEmailProvider(): array
+    {
+        return [
+            'Simple email' => ['user@example.com'],
+            'Email with dots' => ['user.name@example.com'],
+            'Email with plus' => ['user+tag@example.com'],
+            'Email with subdomain' => ['user@mail.example.com'],
+            'Email with numbers' => ['user123@example.com'],
+            'Email with hyphens' => ['user-name@example.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidEmailProvider
+     */
+    public function testInvalidEmailFormats(string $email): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid email address: '$email'.");
+
+        new CustomerDetails(null, $email, null);
+    }
+
+    public static function invalidEmailProvider(): array
+    {
+        return [
+            'Missing @' => ['userexample.com'],
+            'Missing domain' => ['user@'],
+            'Missing local part' => ['@example.com'],
+            'Double @' => ['user@@example.com'],
+            'Spaces in email' => ['user name@example.com'],
+            'Missing TLD' => ['user@example'],
+            'Empty string' => [''],
+        ];
+    }
+
+    public function testJsonSerializationWithAllFields(): void
+    {
+        $customerDetails = new CustomerDetails(
+            'John Doe',
+            'john.doe@example.com',
+            '9876543210'
+        );
+
+        $json = json_encode($customerDetails);
+        $decoded = json_decode($json, true);
+
+        $this->assertArrayHasKey('name', $decoded);
+        $this->assertArrayHasKey('email', $decoded);
+        $this->assertArrayHasKey('phoneNumber', $decoded);
+        $this->assertEquals('John Doe', $decoded['name']);
+        $this->assertEquals('john.doe@example.com', $decoded['email']);
+        $this->assertEquals('9876543210', $decoded['phoneNumber']);
+    }
+
+    public function testJsonSerializationWithNullFields(): void
+    {
+        $customerDetails = new CustomerDetails(null, null, null);
+
+        $json = json_encode($customerDetails);
+        $decoded = json_decode($json, true);
+
+        $this->assertArrayNotHasKey('name', $decoded);
+        $this->assertArrayNotHasKey('email', $decoded);
+        $this->assertArrayNotHasKey('phoneNumber', $decoded);
+        $this->assertEmpty($decoded);
+    }
+
+    public function testJsonSerializationWithPartialFields(): void
+    {
+        $customerDetails = new CustomerDetails('John Doe', null, '9876543210');
+
+        $json = json_encode($customerDetails);
+        $decoded = json_decode($json, true);
+
+        $this->assertArrayHasKey('name', $decoded);
+        $this->assertArrayNotHasKey('email', $decoded);
+        $this->assertArrayHasKey('phoneNumber', $decoded);
+        $this->assertEquals('John Doe', $decoded['name']);
+        $this->assertEquals('9876543210', $decoded['phoneNumber']);
+    }
+
+    public function testSpecialCharactersInName(): void
+    {
+        $specialName = "John O'Reilly-Smith Jr.";
+        $customerDetails = new CustomerDetails($specialName, 'john@example.com', '9876543210');
+
+        $this->assertEquals($specialName, $customerDetails->getName());
+    }
+
+    public function testUnicodeCharactersInName(): void
+    {
+        $unicodeName = 'José García Müller 中文名';
+        $customerDetails = new CustomerDetails($unicodeName, 'jose@example.com', '9876543210');
+
+        $this->assertEquals($unicodeName, $customerDetails->getName());
+        
+        $json = json_encode($customerDetails);
+        $decoded = json_decode($json, true);
+        $this->assertEquals($unicodeName, $decoded['name']);
+    }
+
+    public function testLongNameValue(): void
+    {
+        $longName = str_repeat('A', 200);
+        $customerDetails = new CustomerDetails($longName, 'test@example.com', '9876543210');
+
+        $this->assertEquals($longName, $customerDetails->getName());
+    }
+
+    public function testEmailWithInternationalDomain(): void
+    {
+        $internationalEmail = 'user@example.co.uk';
+        $customerDetails = new CustomerDetails(null, $internationalEmail, null);
+
+        $this->assertEquals($internationalEmail, $customerDetails->getEmail());
+    }
+}

--- a/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
+++ b/tests/Unit/payments/v2/models/request/builders/StandardCheckoutPayRequestBuilderTest.php
@@ -327,4 +327,232 @@ class StandardCheckoutPayRequestBuilderTest extends BaseTestCase
         $result = $builder->prefillUserLoginDetails($prefillDetails);
         $this->assertSame($builder, $result);
     }
+
+    public function testBuildPaymentRequestWithCustomerDetails(): void
+    {
+        $builder = StandardCheckoutPayRequestBuilder::builder();
+        $result = $builder->customerDetails(new CustomerDetails('John Doe', 'john.doe@example.com', '9876543210'));
+        $this->assertSame($builder, $result);
+    }
+
+    public function testBuildPaymentRequestWithInvalidCustomerDetailsCustomerDetails(): void
+    {
+        $emailId = "";
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid email address: '. "'$emailId'.");
+        $builder = StandardCheckoutPayRequestBuilder::builder();
+        $result = $builder->customerDetails(new CustomerDetails('John Doe', $emailId, '9876543210'));
+    }
+
+    public function testBuildPaymentRequestWithValidCustomerDetails(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->customerDetails(new CustomerDetails('John Doe', 'john.doe@example.com', '9876543210'))
+            ->build();
+
+        $this->assertInstanceOf(StandardCheckoutPayRequest::class, $request);
+        $customerDetails = $request->getCustomerDetails();
+        $this->assertInstanceOf(CustomerDetails::class, $customerDetails);
+        $this->assertEquals('John Doe', $customerDetails->getName());
+        $this->assertEquals('john.doe@example.com', $customerDetails->getEmail());
+        $this->assertEquals('9876543210', $customerDetails->getPhoneNumber());
+    }
+
+    public function testCustomerDetailsAbsentByDefault(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->build();
+
+        $this->assertNull($request->getCustomerDetails());
+    }
+
+    public function testCustomerDetailsOmittedFromJsonWhenNull(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->build();
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+        $this->assertArrayNotHasKey('customerDetails', $decoded);
+    }
+
+    public function testCustomerDetailsPresentInJsonWhenSet(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->customerDetails(new CustomerDetails('John Doe', 'john.doe@example.com', '9876543210'))
+            ->build();
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+        $this->assertArrayHasKey('customerDetails', $decoded);
+        $this->assertEquals('John Doe', $decoded['customerDetails']['name']);
+        $this->assertEquals('john.doe@example.com', $decoded['customerDetails']['email']);
+        $this->assertEquals('9876543210', $decoded['customerDetails']['phoneNumber']);
+    }
+
+    public function testCustomerDetailsWithPartialData(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->customerDetails(new CustomerDetails('John Doe', null, '9876543210'))
+            ->build();
+
+        $customerDetails = $request->getCustomerDetails();
+        $this->assertEquals('John Doe', $customerDetails->getName());
+        $this->assertNull($customerDetails->getEmail());
+        $this->assertEquals('9876543210', $customerDetails->getPhoneNumber());
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+        $this->assertArrayHasKey('customerDetails', $decoded);
+        $this->assertArrayHasKey('name', $decoded['customerDetails']);
+        $this->assertArrayNotHasKey('email', $decoded['customerDetails']);
+        $this->assertArrayHasKey('phoneNumber', $decoded['customerDetails']);
+    }
+
+    public function testCustomerDetailsFluentInterface(): void
+    {
+        $builder = StandardCheckoutPayRequestBuilder::builder();
+
+        $result = $builder->customerDetails(new CustomerDetails('John Doe', 'john@example.com', '9876543210'));
+        $this->assertSame($builder, $result);
+    }
+
+    public function testCustomerDetailsWithInvalidEmail(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid email address: 'invalid-email'.");
+
+        StandardCheckoutPayRequestBuilder::builder()
+            ->customerDetails(new CustomerDetails('John Doe', 'invalid-email', '9876543210'));
+    }
+
+    public function testCustomerDetailsWithInvalidPhoneNumber(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid phoneNumber '12345': expected a 10-digit number or E.164 format");
+
+        StandardCheckoutPayRequestBuilder::builder()
+            ->customerDetails(new CustomerDetails('John Doe', 'john@example.com', '12345'));
+    }
+
+    public function testBuildPaymentRequestWithBothPrefillAndCustomerDetails(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->prefillUserLoginDetails($prefillDetails)
+            ->customerDetails(new CustomerDetails('John Doe', 'john.doe@example.com', '9876543210'))
+            ->build();
+
+        $this->assertInstanceOf(StandardCheckoutPayRequest::class, $request);
+        
+        // Verify prefillUserLoginDetails
+        $retrievedPrefill = $request->getPrefillUserLoginDetails();
+        $this->assertInstanceOf(PrefillUserLoginDetails::class, $retrievedPrefill);
+        $this->assertEquals('9876543210', $retrievedPrefill->getPhoneNumber());
+
+        // Verify customerDetails
+        $customerDetails = $request->getCustomerDetails();
+        $this->assertInstanceOf(CustomerDetails::class, $customerDetails);
+        $this->assertEquals('John Doe', $customerDetails->getName());
+        $this->assertEquals('john.doe@example.com', $customerDetails->getEmail());
+        $this->assertEquals('9876543210', $customerDetails->getPhoneNumber());
+    }
+
+    public function testJsonSerializationWithBothPrefillAndCustomerDetails(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->prefillUserLoginDetails($prefillDetails)
+            ->customerDetails(new CustomerDetails('John Doe', 'john.doe@example.com', '9876543210'))
+            ->build();
+
+        $json = json_encode($request);
+        $decoded = json_decode($json, true);
+
+        $this->assertArrayHasKey('prefillUserLoginDetails', $decoded);
+        $this->assertEquals('9876543210', $decoded['prefillUserLoginDetails']['phoneNumber']);
+
+        $this->assertArrayHasKey('customerDetails', $decoded);
+        $this->assertEquals('John Doe', $decoded['customerDetails']['name']);
+        $this->assertEquals('john.doe@example.com', $decoded['customerDetails']['email']);
+        $this->assertEquals('9876543210', $decoded['customerDetails']['phoneNumber']);
+    }
+
+    public function testCustomerDetailsWithE164PhoneNumber(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->customerDetails(new CustomerDetails('John Doe', 'john@example.com', '+919876543210'))
+            ->build();
+
+        $customerDetails = $request->getCustomerDetails();
+        $this->assertEquals('+919876543210', $customerDetails->getPhoneNumber());
+    }
+
+    public function testBackwardCompatibilityPrefillUserLoginDetailsWithObject(): void
+    {
+        $testData = TestDataProvider::getPaymentRequestData();
+        $prefillDetails = new PrefillUserLoginDetails('9876543210');
+
+        // Test that the old API signature still works (backward compatibility)
+        $request = StandardCheckoutPayRequestBuilder::builder()
+            ->merchantOrderId($testData['merchantOrderId'])
+            ->amount($testData['amount'])
+            ->message($testData['message'])
+            ->redirectUrl($testData['redirectUrl'])
+            ->prefillUserLoginDetails($prefillDetails)
+            ->build();
+
+        $this->assertInstanceOf(StandardCheckoutPayRequest::class, $request);
+        $retrieved = $request->getPrefillUserLoginDetails();
+        $this->assertInstanceOf(PrefillUserLoginDetails::class, $retrieved);
+        $this->assertEquals('9876543210', $retrieved->getPhoneNumber());
+    }
 }


### PR DESCRIPTION
Need to pass CustomerDetails from PHP SDK to standard checkout pay request (checkout/v2/pay). This will ensure 
1. User phone number is prefilled in login flows for PHP SDK users
2. Customer Details are populated and users will receive notifications on them given that merchant has opted to send them.